### PR TITLE
reformat learning guide to have nested data

### DIFF
--- a/phil/s009-learning-guide.md
+++ b/phil/s009-learning-guide.md
@@ -6,17 +6,17 @@
 title: 'Physics'
 page_ids: [ 234, 345, 456 ]
 children: [
-  { id:123, title: 'Kinematics', chapter_section: '5'
+  { title: 'Kinematics', chapter_section: '5'
     questions_answered_count: 50
     current_level: 0.5
     page_ids: [ 234, 345, 456 ]
     children: [
-      { id:1231, title: 'Kinematics in 1 dimension', chapter_section: '5.1'
+      { title: 'Kinematics in 1 dimension', chapter_section: '5.1'
         questions_answered_count: 30
         current_level: 0.1
         page_ids: [ 234, 345 ] # The name of this field should correspond to what /practice route expects
       }
-      { id:1232, title: 'Kinematics in 2 dimensions', chapter_section: '5.2'
+      { title: 'Kinematics in 2 dimensions', chapter_section: '5.2'
         questions_answered_count: 20
         current_level: 0.7
         page_ids: [ 456 ]

--- a/phil/s009-learning-guide.md
+++ b/phil/s009-learning-guide.md
@@ -4,28 +4,24 @@
 
 ```coffee
 title: 'Physics'
-fields: [
-  { id:123, title: 'Kinematics', number: '5'
-    questions_answered_count: 48
+groups: [
+  { id:123, title: 'Kinematics', chapter_section: '5'
+    questions_answered_count: 50
     current_level: 0.5
-    page_ids: [ 234, 345 ] # Maybe this would be pages instead (and contain all the info)?
-    practice_count: 12
+    page_ids: [ 234, 345, 456 ]
+    children: [
+      { id:1231, title: 'Kinematics in 1 dimension', chapter_section: '5.1'
+        questions_answered_count: 30
+        current_level: 0.1
+        page_ids: [ 234, 345 ] # The name of this field should correspond to what /practice route expects
+      }
+      { id:1232, title: 'Kinematics in 2 dimensions', chapter_section: '5.2'
+        questions_answered_count: 20
+        current_level: 0.7
+        page_ids: [ 456 ]
+      }
+    ]
   }
   ...
-]
-```
-
-`GET /api/courses/1/stats/topics/123`
-
-```coffee
-id: 123
-title: 'Kinematics'
-number: '5'
-fields: [
-  { id:234, title: 'Kinematics in one dimension', number: '5.1'
-    questions_answered_count: 20
-    current_level: 0.9
-    practice_count: 4
-  }
 ]
 ```

--- a/phil/s009-learning-guide.md
+++ b/phil/s009-learning-guide.md
@@ -4,7 +4,8 @@
 
 ```coffee
 title: 'Physics'
-groups: [
+page_ids: [ 234, 345, 456 ]
+children: [
   { id:123, title: 'Kinematics', chapter_section: '5'
     questions_answered_count: 50
     current_level: 0.5

--- a/phil/s009-learning-guide.md
+++ b/phil/s009-learning-guide.md
@@ -1,6 +1,6 @@
 # Learning Guide JSON
 
-`GET /api/courses/1/stats`
+`GET /api/courses/1/guide`
 
 ```coffee
 title: 'Physics'


### PR DESCRIPTION
Each entry in `children:` should be structured the same as the root node (to allow the drill-down)