### PR TITLE
proposed change to recording who is supposed to get which task

### DIFF
--- a/phil/s013-course-periods.md
+++ b/phil/s013-course-periods.md
@@ -1,4 +1,4 @@
-Screens: 
+Screens:
 
 - Calendar Popup (read-only)
 - Roster (Read-only)
@@ -21,17 +21,36 @@ default_due_time: ??
 default_open_time: ??????
 ```
 
-# HW Builder
+# HW Builder (also iReading Builder)
 
 Initial `POST`: contains period times
 Saving:
 
 ```coffee
-PATCH /plans/1 with { periods: [ {id: , due_at: , opens_at: } ] }
+PATCH /plans/1 with { tasking_plans: [ {target_id: , target_type:, due_at: , opens_at: } ] }
+```
+
+e.g.
+
+```coffee
+{ tasking_plans: [ { target_id: "42", target_type: "period", due_at: timestamp_here, opens_at: timestamp_here } ] }
 ```
 
 # Dashboard / Calendar
 need the endpoint to have the same due time / tasking information as HW builder (parallel to how we are moving due_at from task plan to tasking plan)
+
+```coffee
+{
+  ...
+  tasking_plans: [
+    target_id: "42",
+    target_type: "period",
+    opens_at: blah,
+    due_at: blah
+  ]
+  ...
+}
+```
 
 # Calendar Popup
 
@@ -58,7 +77,7 @@ in the export for BE
    period: { id, name: },
    data_heading: {},   # same as existing
    student_data: []    # same as existing
-  },  # repeat this for each period 
+  },  # repeat this for each period
 ]
 ```
 


### PR DESCRIPTION
Currently, the BE offers a set of generic task plan endpoints under `/plan`.  There are no endpoints for specific kinds of task plans, e.g. no `/homework_plan` or `/reading_plan` endpoints.  The FE has code that handles the generic `/plan` endpoints.

The original draft of this napkin note has a `periods` array to specify who should be assigned the tasks from the plan.  In the same way that the BE thinks about task plans in a generalized way, it also thinks about who will receive tasks from a task plan in a generalized way: task plans have a list of "tasking plans" which tell us who to assign the eventual tasks to and when they should open and become due.   

Since we'll eventually have other non-period recipients of tasks (e.g. individual students), and because the underlying plan structure is already generic, I'd much rather not use a `periods` array but instead a `tasking_plans` array here.  

A `tasking_plan` in JSON looks essentially just like the `period` JSON before except it also has a `type` field to marry with the `id` field.

As was previously stated in the napkin note, the dashboard endpoint will follow the same style as whatever we decide here, and I just put an example in for the new style.

Details that are more minor:

1. If the name `tasking_plan` is not good for the FE we can name it whatever as long as it can work for non-period taskees as well.  
2. The real field names in the `tasking_plan` are `target_id` and `target_type` (instead of `id` and `type`) to indicate that these fields identify which thing should be receiving the task and not the identity of the `tasking_plan` itself.  I am up for making these whatever y'all want.
