### PR TITLE
Added gdoc link for commenting

### DIFF
--- a/lakshmi/clue-performance-improvement-plans.md
+++ b/lakshmi/clue-performance-improvement-plans.md
@@ -1,5 +1,7 @@
 # Overview
 
+GDOC: For comments: https://docs.google.com/document/d/15_hy_B-cUSomG8uw94VNQavy9aKwHIj3jK-MdQptBS8/edit
+
 Right now the performance forecast pages are significantly slow.
 While a few surface level issues have made the page load tolerable,
 more work is needed to make the performance optimal.  This document


### PR DESCRIPTION
Love github for napkin notes, but don't find pull requests to be adequate for commenting on markdown pages. I wonder if we could eventually use Hypothes.is for that. But for now, adding in a gdoc link for comments.