### PR TITLE
An alternative date helper format

### DIFF
--- a/kevin/demo_script_updates.md
+++ b/kevin/demo_script_updates.md
@@ -92,6 +92,18 @@ and convenience methods for specific `n` should be defined in terms of these.
 
 Care should be taken to account for timezones and other `Course`- or `User`- specific time settings.
 
+As an alternative to the date helpers, `opens_at` and `due_at` helpers could be created that would output yaml text.  For instance: `<%= due_at 4.days.ago %>` would output call `school_day_on_or_before` internally and then output "due_at: YYY-MM-DD" into the yaml.
+
+This would allow assignments to be specified as:
+```yaml
+    title: Read stuffs
+    periods:
+      - id: p1
+        <%= opens_at 1.week.ago %>
+        <%= due_at 2.days.from_now %>
+        students: {...}
+```
+
 ## HW Description Updates
 
 The fields for `Homework` assignments need to include:


### PR DESCRIPTION
An idea for an alternative date helper methods.  Whenever I tweak the imports it's kind of a pain to remember and type due_in_X_days.  I think it'd be easier to just use the standard Rails X.days format.