### PR TITLE
Slack: Add suggestion to use "Snooze" instead of "Set yourself Away"

### DIFF
--- a/phil/slack-suggestions.md
+++ b/phil/slack-suggestions.md
@@ -2,7 +2,8 @@ Some suggestions for trying this out:
 
 - It's better to let too many people know than not enough
 - Default to discussing in channels unless it really is just a discussion with 1 other person
-- If having a bot in your channel is annoying, make a separate channel for them (ie `#tutor-alerts`)
+- Instead of using `Set yourself Away`, use the :bell: to "snooze" for a bit. This way people still see that you are online but will not expect you to respond immediately.
+- If having a bot in your channel is annoying, make a separate channel for them (ie `#tutor-stream`)
 - Add a Reaction to a chat [:thumbsup::5 :thumbsdown::2 ] instead of just typing "ok", "yeah", "no way" (or use it for voting like [:hamburger::2 :pizza::1 :ramen::3 :fried_shrimp::2 ])
 - use `/remind` to remind folks about stuff (like to fill out the retrospective notes, or that a sprint will end)
 


### PR DESCRIPTION
"Set yourself Away" makes it appear as if you are offline, which may be confusing to others. Also, snoozing will turn off sounds and Toast notifications (useful for meetings or screen-sharing)