### PR TITLE
add support for deploying multiple repositories

### DIFF
--- a/phil/deploy.sh
+++ b/phil/deploy.sh
@@ -10,6 +10,24 @@ WHAT=$1
 TO_VERB=$2
 ENVIRONMENT=$3
 
+function run_ansible_command ()
+{
+  DEPLOY_COMMAND=$1
+  DEPLOY_NOTES=$2
+  # --extra-vars "reset_rails_db=true"
+
+  echo "Running ansible-playbook ${DEPLOY_COMMAND}"
+
+  ansible-playbook \
+    -i environments/${ENVIRONMENT}/inventory \
+    --private-key ~/.ssh/tutor-${ENVIRONMENT}-kp.pem \
+    --vault-password-file ~/.vault/${ENVIRONMENT}  \
+    --skip-tags configuration \
+    --extra-vars="deploy_notes='${DEPLOY_NOTES}'" \
+    ${DEPLOY_COMMAND}
+}
+
+
 # If no arguments were specified then print help
 if [ -z "${WHAT}" -o '--help' == "${WHAT}" ]
 then
@@ -19,8 +37,9 @@ then
   deploy tutor-js#123 to dev   (PullRequest with the merge to master)
   deploy tutor-js#123! to dev  (PullRequest without the merge to master)
   deploy tutor-js/branch/name/with/slashes! to dev (branch)
-  deploy qa to dev     (makes dev look exactly like qa)
-  deploy d34db33f      (applies the manifest)
+  deploy qa to dev             (makes dev look exactly like qa)
+  deploy d34db33f to dev       (applies the manifest)
+  deploy 'qa tutor-js#123 exercises/master' to dev (apply multiple repositories)
   deploy enqueue 'col123 col234 col10074' to dev
                  (enqueues PDFs on legacy-textbook-{dev}.cnx.org)
   "
@@ -62,168 +81,215 @@ then
 else
   # workon tutordep
 
-  if [ 'qa' == "${WHAT}" -o 'prod' == "${WHAT}" -o 'staging' == "${WHAT}" -o 'dev' == "${WHAT}" -o 'latest' == "${WHAT}" ]
-  then
+  ANSIBLE_COMMANDS=()
+  # These make the links for the deploy message and their lengths must match up
+  WHAT_TEXTS=()
+  WHAT_URLS=()
 
-    # Make sure all the repos have the latest commits for manifestly
-    ALL_REPOS=$(ls ..)
-    for REPO_NAME in ${ALL_REPOS}
-    do
-      if [ -d "../${REPO_NAME}/.git" ]
+  for WHAT_CMD in ${WHAT}
+  do
+
+    if [ 'qa' == "${WHAT_CMD}" -o 'prod' == "${WHAT_CMD}" -o 'staging' == "${WHAT_CMD}" -o 'dev' == "${WHAT_CMD}" -o 'latest' == "${WHAT_CMD}" ]
+    then
+
+      # Make sure all the repos have the latest commits for manifestly
+      ALL_REPOS=$(ls ..)
+      for REPO_NAME in ${ALL_REPOS}
+      do
+        if [ -d "../${REPO_NAME}/.git" ]
+        then
+          echo "Updating ${REPO_NAME} with new commits from github"
+          X=$(cd "../${REPO_NAME}" && git fetch --all)
+        fi
+      done
+
+      # Deploying from an existing manifest file
+      if [ 'prod' == "${WHAT_CMD}" ]
       then
-        echo "Updating ${REPO_NAME} with new commits from github"
-        X=$(cd "../${REPO_NAME}" && git fetch --all)
+        MANIFEST_HOST='tutor.openstax.org'
+      else
+        MANIFEST_HOST="tutor-${WHAT_CMD}.openstax.org"
       fi
-    done
 
-    # Deploying from an existing manifest file
-    if [ 'prod' == "${WHAT}" ]
-    then
-      MANIFEST_HOST='tutor.openstax.org'
-    else
-      MANIFEST_HOST="tutor-${WHAT}.openstax.org"
-    fi
-
-    MANIFEST_URL="https://${MANIFEST_HOST}/rev.txt"
-    echo "Deploying from manifest file on ${MANIFEST_URL}"
-    cd .. # manifestly needs to run 1 directory up
-    curl ${MANIFEST_URL}
-    curl ${MANIFEST_URL} | manifestly apply --file /dev/stdin
-    cd ./tutor-deployment
-
-    WHAT_URL=${MANIFEST_URL}
-    DEPLOY_COMMAND='tutor_web.yml' # just enough to generate a manifestly commit
-
-  elif [ $(expr ${WHAT} : '^\([a-f0-9]*\)$') ]
-  then
-
-    # Make sure all the repos have the latest commits for manifestly
-    ALL_REPOS=$(ls ..)
-    for REPO_NAME in ${ALL_REPOS}
-    do
-      if [ -d "../${REPO_NAME}/.git" ]
+      MANIFEST_URL="https://${MANIFEST_HOST}/rev.txt"
+      echo "Deploying from manifest file on ${MANIFEST_URL}"
+      cd .. # manifestly needs to run 1 directory up
+      curl --progress ${MANIFEST_URL}
+      MANIFEST_ERROR=$(curl --progress ${MANIFEST_URL} | manifestly apply --file /dev/stdin)
+      if [ -n "${MANIFEST_ERROR}" ]
       then
-        echo "Updating ${REPO_NAME} with new commits from github"
-        X=$(cd ../${REPO_NAME} && git fetch --all)
+        echo ${MANIFEST_ERROR}
+        exit 1
       fi
-    done
+      cd ./tutor-deployment
 
-    MANIFEST_SHA=${WHAT}
-    MANIFEST_URL="https://raw.githubusercontent.com/openstax/deploy-manifests/${MANIFEST_SHA}/tutor"
+      WHAT_URL=${MANIFEST_URL}
 
-    echo "Deploying from manifest file on ${MANIFEST_URL}"
-    cd .. # manifestly needs to run 1 directory up
-    curl ${MANIFEST_URL}
-    curl ${MANIFEST_URL} | manifestly apply --file /dev/stdin
-    cd ./tutor-deployment
+      # Append to the set of ansible commands that need to run
+      ANSIBLE_COMMANDS+=('tutor_web.yml')
+      ANSIBLE_COMMANDS+=('accounts_web.yml')
+      ANSIBLE_COMMANDS+=('exercises_web.yml')
 
-    WHAT_URL=${MANIFEST_URL}
-    DEPLOY_COMMAND='tutor_web.yml' # just enough to generate a manifestly commit
-
-  else
-
-    REPO_NAME=$(expr ${WHAT} : '\([^@#\/]*\)') # Grab the first part of `tutor@d49e32`
-
-    COMMIT_SHA=$(expr ${WHAT} : '[^@]*@\([a-f0-9]*\)$') # ie `tutor@d49e32`
-    PR_NUMBER=$(expr ${WHAT} : '[^#]*#\([0-9]*\)$')    # ie `tutor#123`
-    PR_NUMBER_NOMERGE=$(expr ${WHAT} : '[^#]*#\([0-9]*\)!$')   # ie `tutor#123!`
-    BRANCH=$(expr ${WHAT} : '[^\/]*\/\(.*\)$')      # ie `tutor/fix/branch/name`
-
-    if [ -z ${REPO_NAME} ]
+    elif [ $(expr ${WHAT_CMD} : '^\([a-f0-9]*\)$') ]
     then
-      echo "Invalid syntax. Must provide a repo name"
-      exit 1
-    fi
 
-    # TODO: Check if the repo is correct
-    cd ../${REPO_NAME}
+      # Make sure all the repos have the latest commits for manifestly
+      ALL_REPOS=$(ls ..)
+      for REPO_NAME in ${ALL_REPOS}
+      do
+        if [ -d "../${REPO_NAME}/.git" ]
+        then
+          echo "Updating ${REPO_NAME} with new commits from github"
+          X=$(cd ../${REPO_NAME} && git fetch --all)
+        fi
+      done
 
+      MANIFEST_SHA=${WHAT_CMD}
+      MANIFEST_URL="https://raw.githubusercontent.com/openstax/deploy-manifests/${MANIFEST_SHA}/tutor"
 
-    if [ "${COMMIT_SHA}" ]
-    then
-      WHAT_URL="https://github.com/openstax/${REPO_NAME}/commit/${COMMIT_SHA}"
+      echo "Deploying from manifest file on ${MANIFEST_URL}"
+      cd .. # manifestly needs to run 1 directory up
+      curl ${MANIFEST_URL}
+      curl ${MANIFEST_URL} | manifestly apply --file /dev/stdin
+      echo "Manifestly done"
+      cd ./tutor-deployment
 
-      ## Commit (MUST be the full commit sha)
-      echo "${REPO_NAME}: Checking out commit ${COMMIT_SHA}"
-      # git fetch origin ${COMMIT_SHA}  || exit 1
-      # git checkout FETCH_HEAD         || exit 1
+      WHAT_URL=${MANIFEST_URL}
 
-      # ## Commit (partial sha)
-      # # (maybe there is a better way to do this?)
-      git checkout master          || exit 1
-      git pull                     || exit 1
-      git checkout ${COMMIT_SHA}   || exit 1
-
-    elif [ "${PR_NUMBER}" ]
-    then
-      WHAT_URL="https://github.com/openstax/${REPO_NAME}/pull/${PR_NUMBER}"
-
-      ## Pull Request (it should fail with error message if it's not mergeable)
-      echo "${REPO_NAME}: Checking out Pull Request ${PR_NUMBER}"
-      git fetch origin pull/${PR_NUMBER}/merge  || exit 1
-      git checkout FETCH_HEAD                   || exit 1
-
-    elif [ "${PR_NUMBER_NOMERGE}" ]
-    then
-      WHAT_URL="https://github.com/openstax/${REPO_NAME}/pull/${PR_NUMBER_NOMERGE}"
-
-      ## Pull Request nomerge (for hotfixes)
-      echo "${REPO_NAME}: Checking out Pull Request ${PR_NUMBER_NOMERGE} with nomerge"
-      git fetch origin pull/${PR_NUMBER_NOMERGE}/head || exit 1
-      git checkout FETCH_HEAD                         || exit 1
-
-    elif [ "${BRANCH}" ]
-    then
-      WHAT_URL="https://github.com/openstax/${REPO_NAME}/tree/${BRANCH}"
-
-      ## Branch
-      echo "${REPO_NAME}: Checking out branch ${BRANCH}"
-      git fetch origin ${BRANCH}  || exit 1
-      git checkout FETCH_HEAD     || exit 1
+      # Append to the set of ansible commands that need to run
+      ANSIBLE_COMMANDS+=('tutor_web.yml')
+      ANSIBLE_COMMANDS+=('accounts_web.yml')
+      ANSIBLE_COMMANDS+=('exercises_web.yml')
 
     else
 
-      echo "Did not understand the command."
-      exit 1
+      REPO_NAME=$(expr ${WHAT_CMD} : '\([^@#\/]*\)') # Grab the first part of `tutor@d49e32`
 
-    fi
+      COMMIT_SHA=$(expr ${WHAT_CMD} : '[^@]*@\([a-f0-9]*\)$') # ie `tutor@d49e32`
+      PR_NUMBER=$(expr ${WHAT_CMD} : '[^#]*#\([0-9]*\)$')    # ie `tutor#123`
+      PR_NUMBER_NOMERGE=$(expr ${WHAT_CMD} : '[^#]*#\([0-9]*\)!$')   # ie `tutor#123!`
+      BRANCH=$(expr ${WHAT_CMD} : '[^\/]*\/\(.*\)$')      # ie `tutor/fix/branch/name`
 
-    cd ../tutor-deployment
+      if [ -z ${REPO_NAME} ]
+      then
+        echo "Invalid syntax. Must provide a repo name"
+        exit 1
+      fi
 
-    if [ 'tutor-js' == "${REPO_NAME}" ]
-    then
-      DEPLOY_COMMAND='tutor_web.yml'
-    elif [ 'tutor-server' == "${REPO_NAME}" ]
-    then
-      DEPLOY_COMMAND='tutor_web.yml'
-    elif [ 'exercises-js' == "${REPO_NAME}" ]
-    then
-      DEPLOY_COMMAND='exercises_web.yml'
-    elif [ 'exercises' == "${REPO_NAME}" ]
-    then
-      DEPLOY_COMMAND='exercises_web.yml'
-    elif [ 'accounts' == "${REPO_NAME}" ]
-    then
-      DEPLOY_COMMAND='accounts_web.yml'
-    else
-      echo "Do not know which deploy command to run for this repo"
-      exit 1
-    fi
-
-  fi # deploy an environment or a specific repo
+      # TODO: Check if the repo is correct
+      cd ../${REPO_NAME}
 
 
-  echo "Running ${DEPLOY_COMMAND} to ${ENVIRONMENT}. sleeping for 5sec"
+      if [ "${COMMIT_SHA}" ]
+      then
+        WHAT_URL="https://github.com/openstax/${REPO_NAME}/commit/${COMMIT_SHA}"
+
+        ## Commit (MUST be the full commit sha)
+        echo "${REPO_NAME}: Checking out commit ${COMMIT_SHA}"
+        # git fetch origin ${COMMIT_SHA}  || exit 1
+        # git checkout FETCH_HEAD         || exit 1
+
+        # ## Commit (partial sha)
+        # # (maybe there is a better way to do this?)
+        git checkout master          || exit 1
+        git pull                     || exit 1
+        git checkout ${COMMIT_SHA}   || exit 1
+
+      elif [ "${PR_NUMBER}" ]
+      then
+        WHAT_URL="https://github.com/openstax/${REPO_NAME}/pull/${PR_NUMBER}"
+
+        ## Pull Request (it should fail with error message if it's not mergeable)
+        echo "${REPO_NAME}: Checking out Pull Request ${PR_NUMBER}"
+        git fetch origin pull/${PR_NUMBER}/merge  || exit 1
+        git checkout FETCH_HEAD                   || exit 1
+
+      elif [ "${PR_NUMBER_NOMERGE}" ]
+      then
+        WHAT_URL="https://github.com/openstax/${REPO_NAME}/pull/${PR_NUMBER_NOMERGE}"
+
+        ## Pull Request nomerge (for hotfixes)
+        echo "${REPO_NAME}: Checking out Pull Request ${PR_NUMBER_NOMERGE} with nomerge"
+        git fetch origin pull/${PR_NUMBER_NOMERGE}/head || exit 1
+        git checkout FETCH_HEAD                         || exit 1
+
+      elif [ "${BRANCH}" ]
+      then
+        WHAT_URL="https://github.com/openstax/${REPO_NAME}/tree/${BRANCH}"
+
+        ## Branch
+        echo "${REPO_NAME}: Checking out branch ${BRANCH}"
+        git fetch origin ${BRANCH}  || exit 1
+        git checkout FETCH_HEAD     || exit 1
+
+      else
+
+        echo "Did not understand the command."
+        exit 1
+
+      fi
+
+      cd ../tutor-deployment
+
+      if [ 'tutor-js' == "${REPO_NAME}" ]
+      then
+        DEPLOY_COMMAND='tutor_web.yml'
+      elif [ 'tutor-server' == "${REPO_NAME}" ]
+      then
+        DEPLOY_COMMAND='tutor_web.yml'
+      elif [ 'exercises-js' == "${REPO_NAME}" ]
+      then
+        DEPLOY_COMMAND='exercises_web.yml'
+      elif [ 'exercises' == "${REPO_NAME}" ]
+      then
+        DEPLOY_COMMAND='exercises_web.yml'
+      elif [ 'accounts' == "${REPO_NAME}" ]
+      then
+        DEPLOY_COMMAND='accounts_web.yml'
+      else
+        echo "Do not know which deploy command to run for this repo"
+        exit 1
+      fi
+
+      # Append to the set of ansible commands that need to run
+      ANSIBLE_COMMANDS+=(${DEPLOY_COMMAND})
+
+    fi # deploy an environment or a specific repo
+
+    # Append to the list of commands
+    WHAT_TEXTS+=(${WHAT_CMD})
+    WHAT_URLS+=(${WHAT_URL})
+
+  done # looping over all the repos/envs to check out before deploying
+
+
+  # If the number of commands is > 1 then just run all of them since there will likely be duplicates
+  ANSIBLE_COMMAND_LENGTH=${#ANSIBLE_COMMANDS[@]}
+
+  echo "Deploying to ${ENVIRONMENT}. sleeping for 5sec"
   sleep 5
 
-  # --extra-vars "reset_rails_db=true"
+  # Generate the markdown links for everything that was deployed
+  WHAT_LINKS=' '
+  WHAT_TEXTS_LENGTH=${#WHAT_TEXTS[@]}
+  for (( i=0; i<${WHAT_TEXTS_LENGTH}; i++ ));
+  do
+    WHAT_URL=${WHAT_URLS[${i}]}
+    WHAT_TEXT=${WHAT_TEXTS[${i}]}
 
-  ansible-playbook \
-    -i environments/${ENVIRONMENT}/inventory \
-    --private-key ~/.ssh/tutor-${ENVIRONMENT}-kp.pem \
-    --vault-password-file ~/.vault/${ENVIRONMENT}  \
-    --skip-tags configuration \
-    --extra-vars="deploy_notes=' (@${USER} ran \`deploy ${WHAT} to dev\` *[<${WHAT_URL}|${WHAT}>]*)'" \
-    ${DEPLOY_COMMAND} $4 $5
+    WHAT_LINKS="${WHAT_LINKS} - <${WHAT_URL}|${WHAT_TEXT}>"
+  done
 
+
+  DEPLOY_NOTES=" (@${USER} ran \`deploy ${WHAT} to ${ENVIRONMENT}\`)${WHAT_LINKS}"
+
+  if [ ${ANSIBLE_COMMAND_LENGTH} == 1 ]
+  then
+    run_ansible_command ${ANSIBLE_COMMANDS[0]} "${DEPLOY_NOTES}"
+  else
+    # TODO: skip duplicate entries
+    run_ansible_command 'accounts_web.yml' "${DEPLOY_NOTES}"
+    run_ansible_command 'exercises_web.yml' "${DEPLOY_NOTES}"
+    run_ansible_command 'tutor_web.yml' "${DEPLOY_NOTES}"
+  fi
 fi


### PR DESCRIPTION
... with one command

Example of the new syntax is `deploy 'qa tutor-js#123 exercises/master' to dev`. This will apply `qa`'s manifest, then the `tutor-js` Pull Request, and then the master version of `exercises`.

Full Syntax:

```
  deploy tutor-js@d34db33f to dev   (deploy a commit)
  deploy tutor-js#123 to dev   (PullRequest with the merge to master)
  deploy tutor-js#123! to dev  (PullRequest without the merge to master)
  deploy tutor-js/branch/name/with/slashes! to dev (branch)
  deploy qa to dev             (makes dev look exactly like qa)
  deploy d34db33f to dev       (applies the manifest)
  deploy 'qa tutor-js#123 exercises/master' to dev (apply multiple repositories)
  deploy enqueue 'col123 col234 col10074' to dev
                 (enqueues PDFs on legacy-textbook-{dev}.cnx.org)
```