### PR TITLE
repos with protected branches should not restrict who can push to master

### DIFF
--- a/checklists.md
+++ b/checklists.md
@@ -2,6 +2,7 @@
 
 - [ ] add `LICENSE.md` file
 - [ ] protect master branch
+  - **Note:** make sure you deselect "Restrict who can push to this branch"
 - [ ] add team (`all`)
 - [ ] add `CONTRIBUTING.md` which links to https://github.com/openstax/napkin-notes/blob/master/CONTRIBUTING.md
 - [ ] add `.travis.yml`


### PR DESCRIPTION
"Restrict who can push to this branch" was enabled for at least one repo and it should be unchecked so devs can merge Pull Requests.

![image](https://cloud.githubusercontent.com/assets/253202/21870502/b03963f4-d82a-11e6-8dc6-9e019bd566dc.png)
