### PR TITLE
add additional checklist items for GitHub repositories

### DIFF
--- a/checklists.md
+++ b/checklists.md
@@ -1,13 +1,17 @@
 # New GitHub Repo
 
-- [ ] add `LICENSE.md` file
+- [ ] add AGPL-3 `LICENSE` file (Example: [tutor-js](https://github.com/openstax/tutor-js/pull/1653))
 - [ ] protect master branch
   - **Note:** make sure you deselect "Restrict who can push to this branch"
 - [ ] add team (`all`)
 - [ ] add `CONTRIBUTING.md` which links to https://github.com/openstax/napkin-notes/blob/master/CONTRIBUTING.md
 - [ ] add `.travis.yml`
 - [ ] add Webhook for Travis-CI
+- [ ] add Webhook for https://codecov.io
+- [ ] add `./script/setup` and `./script/test` (optional) [Why do this?](https://githubengineering.com/scripts-to-rule-them-all/)
+  - Examples: [1](https://github.com/Connexions/cnx-rulesets) [2](https://github.com/Connexions/cnx-easybake) [3](https://github.com/openstax/ostext-style-guide)
 - [ ] add `.editorconfig` file (see [website](http://editorconfig.org) and [Atom.io plugin](https://atom.io/packages/editorconfig)
+- [ ] create a `README.md`
 
 
 # New Slack Channel


### PR DESCRIPTION
This adds "Create a Readme", add "Code coverage", and _optionally_ `./script/setup` and `./script/test` to get "up and running" easily.

/cc @mwharrison 