### PR TITLE
allow everyone to see security Alerts

### DIFF
--- a/checklists.md
+++ b/checklists.md
@@ -4,6 +4,7 @@
 - [ ] protect master branch
   - **Note:** make sure you deselect "Restrict who can push to this branch"
 - [ ] add team (`all`)
+- [ ] add team `all` to the Settings -> Alerts so everyone can see security vulnerabilities messages
 - [ ] add `CONTRIBUTING.md` which links to https://github.com/openstax/napkin-notes/blob/master/CONTRIBUTING.md
 - [ ] add `./script/setup` and `./script/test` (optional) [Why do this?](https://githubengineering.com/scripts-to-rule-them-all/)
   - Examples: [1](https://github.com/Connexions/cnx-rulesets) [2](https://github.com/Connexions/cnx-easybake) [3](https://github.com/openstax/ostext-style-guide)


### PR DESCRIPTION
GitHub crawls through your repository's `Gemfile`, `package-lock.json` files and reports security vulnerabilities. But only people in the Settings -> Alerts list can see them. So make sure that the `all` team is added to that list so everyone sees them.

How should we fix this

# Example Security Alert
![image](https://user-images.githubusercontent.com/253202/34530349-e8256112-f07c-11e7-811e-bbd67cafa05d.png)

# Page to change the settings
![image](https://user-images.githubusercontent.com/253202/34530342-e04bf94c-f07c-11e7-8389-992acf80aab6.png)

/cc @nathanstitt @jpslav @m1yag1 @reedstrm @DarkPrinceFrost @dtwilliamson 