### PR TITLE
add vulnerability alerts

### DIFF
--- a/checklists.md
+++ b/checklists.md
@@ -4,6 +4,7 @@
 - [ ] protect master branch
   - **Note:** make sure you deselect "Restrict who can push to this branch"
 - [ ] add team (`all`)
+- [ ] add team (`all`) to the Settings -> Alerts -> Vulnerability alerts
 - [ ] add `CONTRIBUTING.md` which links to https://github.com/openstax/napkin-notes/blob/master/CONTRIBUTING.md
 - [ ] add `./script/setup` and `./script/test` (optional) [Why do this?](https://githubengineering.com/scripts-to-rule-them-all/)
   - Examples: [1](https://github.com/Connexions/cnx-rulesets) [2](https://github.com/Connexions/cnx-easybake) [3](https://github.com/openstax/ostext-style-guide)


### PR DESCRIPTION
Currently only Admins can see the vulnerability alerts for a repo. This changes it so that _everyone_ is aware of them.

By letting everyone see them, the thinking is that they will be fixed sooner.